### PR TITLE
Remove libblastrampoline_jll explicit compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -37,7 +37,6 @@ Primes = "0.5"
 ApproxFun = "0.13"
 PeriodicSchurDecompositions = "0.1.1"
 julia = "1.7"
-libblastrampoline_jll = "3.0.4"
 
 [extras]
 LinearMaps = "7a12625a-238d-50fd-b39a-03d52299707e"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,6 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
 ApproxFun = "28f2ccd6-bb30-5033-b560-165f7b14dc2f"
 PeriodicSchurDecompositions = "e5aedecb-f6c0-4c91-b6ff-fbae4296f459"
-libblastrampoline_jll = "8e850b90-86db-534c-a0d3-1478176c7d93"
 
 [compat]
 DescriptorSystems = "1"


### PR DESCRIPTION
We need to remove the libblastrampoline_jll compat here so that the `julia` version can dictate the the correct libblastrampoline_jll version.